### PR TITLE
Fix YouTrack authentication (typo in OAuth bearer)

### DIFF
--- a/lib/hermetic/youtrack.ex
+++ b/lib/hermetic/youtrack.ex
@@ -12,7 +12,7 @@ defmodule Hermetic.YouTrack do
     Send HTTP GET request to provided YouTrack endpoint.
   """
   def request(endpoint) do
-    headers = [{"authorization", "bearer " <> token()}, {"accept", "application/json"}]
+    headers = [{"authorization", "Bearer " <> token()}, {"accept", "application/json"}]
     HTTPoison.get!(base_url() <> endpoint, headers).body |> Poison.decode!()
   end
 


### PR DESCRIPTION
That fixes the issue I've described earlier (where only public YouTrack projects would be returned by `Hermetic.YouTrack.project_ids()`).