### PR TITLE
Add NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,9 @@
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, gitignore, mix-to-nix, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
+  outputs = { self, nixpkgs, gitignore, mix-to-nix, flake-utils, ... }: ({
+    nixosModules.hermetic = import ./module.nix;
+  } // flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs { inherit system; };
 
@@ -28,5 +30,5 @@
         type = "app";
         program = "${self.defaultPackage."${system}"}/bin/hermetic";
       };
-    });
+    }));
 }

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.hermetic;
+in
+
+{
+  options = {
+    services.hermetic = {
+      enable = mkEnableOption "Hermetic Slack bot for YouTrack";
+
+      package = mkOption {
+        default = pkgs.hermetic;
+        defaultText = "pkgs.hermetic";
+        type = types.package;
+      };
+
+      environmentFile = mkOption {
+        default = null;
+        type = with types; nullOr path;
+      };
+
+      virtualHost = mkOption {
+        default = "hermetic";
+        type = types.nullOr types.str;
+      };
+
+      port = mkOption {
+        default = 59468;
+        type = types.int;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.epmd.enable = true;
+
+    services.nginx.virtualHosts = mkIf (cfg.virtualHost != null) {
+      "${cfg.virtualHost}".locations."/".proxyPass =
+        "http://127.0.0.1:${toString cfg.port}";
+    };
+
+    systemd.services.hermetic = rec {
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "epmd.service" "network.target" ];
+      after = requires;
+      path = with pkgs; [ elixir ];
+
+      environment = {
+        HOME = "/tmp";
+        RELEASE_TMP = "/tmp";
+        RELEASE_NODE = "hermetic@127.0.0.1";
+        RELEASE_DISTRIBUTION = "name";
+        HERMETIC_PORT = "${toString cfg.port}";
+      };
+
+      script = ''
+        export RELEASE_COOKIE=$(head -c24 /dev/urandom | base64)
+        ${cfg.package}/bin/hermetic start
+      '';
+
+      serviceConfig = {
+        EnvironmentFile = optional (cfg.environmentFile != null) cfg.environmentFile;
+        DynamicUser = true;
+        WorkingDirectory = cfg.package;
+        Restart = "on-failure";
+        RestartSec = "1min";
+      };
+    };
+  };
+}


### PR DESCRIPTION
This simply adds the module removed from `serokell.nix` in https://github.com/serokell/serokell.nix/pull/10 - so it can be in the same repository as the package's definition.