### PR TITLE
Update 'gitignore'

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,18 +32,22 @@
       }
     },
     "gitignore": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1594969032,
-        "narHash": "sha256-nbZfz02QoVe1yYK7EtCV7wMi4VdHzZEoPg20ZSDo9to=",
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
         "owner": "hercules-ci",
-        "repo": "gitignore",
-        "rev": "c4662e662462e7bf3c2a968483478a665d00e717",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
-        "repo": "gitignore",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,10 @@
     flake = false;
   };
 
-  inputs.gitignore.url = "github:hercules-ci/gitignore";
-  inputs.gitignore.flake = false;
+  inputs.gitignore = {
+    url = "github:hercules-ci/gitignore.nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
 
   inputs.mix-to-nix.url = "github:serokell/mix-to-nix/transumption";
   inputs.mix-to-nix.flake = false;
@@ -21,7 +23,7 @@
       pkgs = import nixpkgs { inherit system; };
 
       mixToNix = (pkgs.callPackage mix-to-nix { }).mixToNix;
-      gitignoreSource = (pkgs.callPackage gitignore { }).gitignoreSource;
+      inherit (gitignore.lib) gitignoreSource;
     in
     {
       defaultPackage = pkgs.callPackage ./derivation.nix { inherit mixToNix gitignoreSource; };


### PR DESCRIPTION
Problem: 'gitignoreSource' is broken in pure evaluation mode with current version of nix.

Solution: Use updated version from 'hercules-ci/gitignore.nix'.